### PR TITLE
adafruit_mqtt_micropython_PUBLISH.py

### DIFF
--- a/mqtt-to-adafruit.py
+++ b/mqtt-to-adafruit.py
@@ -1,4 +1,4 @@
-#
+# OPEN-SOURCE isAwesome!
 # Micropython ESP8266 code to Publish temperature sensor data to an Adafruit IO Feed using the MQTT protocol
 # Also publishes statistics on the number of free bytes on the micropython Heap
 #


### PR DESCRIPTION
Publishing MQTT messages to the free online-broker, Adafruit.io using nothing but the MicroPyhton language on ESP-12E dev board.